### PR TITLE
fix: update CI workflow branches and paths to ignore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,21 @@ name: CI
 
 on:
   push:
-    branches: [main, develop, 'feature/*', 'fix/*', 'hotfix/*']
+    branches: [main, development]
+    paths-ignore:
+      - '**.md'
+      - .claude/**
+      - 'docs/**'
+      - '.github/**'
+      - '!.github/workflows/**'  # Still run if workflows change
   pull_request:
-    branches: [main, develop]
-
+    branches: [main, development]
+    paths-ignore:
+      - '**.md'
+      - .claude/**
+      - 'docs/**'
+      - '.github/**'
+      - '!.github/workflows/**'  # Still run if workflows change
 jobs:
   lint:
     name: Lint


### PR DESCRIPTION
This pull request updates the CI workflow configuration to better control when checks are triggered. The main changes are to branch targeting and which files will trigger the workflow.

Workflow trigger improvements:

* Updated the branch list for both `push` and `pull_request` events to target `main` and `development` instead of `main`, `develop`, and feature/hotfix branches.
* Added `paths-ignore` rules to prevent the workflow from running on changes to markdown files, the `.claude` directory, documentation, and most files in `.github`, except for workflow changes.